### PR TITLE
Automatically refresh completions after every call.

### DIFF
--- a/autoload/asyncomplete/sources/mocword.vim
+++ b/autoload/asyncomplete/sources/mocword.vim
@@ -56,7 +56,7 @@ function! s:on_event(job_id, data, event)
   let l:candidates = split(a:data[0], " ")
   let l:items = s:generate_items(l:candidates)
 
-  call asyncomplete#complete(s:opt["name"], s:ctx, l:startcol, l:items)
+  call asyncomplete#complete(s:opt["name"], s:ctx, l:startcol, l:items, 1)
 endfunction
 
 function! s:generate_items(candidates)


### PR DESCRIPTION
Plugin should update its list of completion candidates each time a new letter is typed. If the desired word is not one of the first 100 returned after typing one letter, it will never be found.