### PR TITLE
Start mocword later, on first completion attempt.

### DIFF
--- a/autoload/asyncomplete/sources/mocword.vim
+++ b/autoload/asyncomplete/sources/mocword.vim
@@ -55,7 +55,7 @@ function! s:on_event(job_id, data, event)
   let l:candidates = split(a:data[0], " ")
   let l:items = s:generate_items(l:candidates)
 
-  call asyncomplete#complete(s:opt["name"], s:ctx, l:startcol, l:items, 1)
+  call asyncomplete#complete(s:opt["name"], s:ctx, l:startcol, l:items)
 endfunction
 
 function! s:generate_items(candidates)

--- a/autoload/asyncomplete/sources/mocword.vim
+++ b/autoload/asyncomplete/sources/mocword.vim
@@ -56,7 +56,7 @@ function! s:on_event(job_id, data, event)
   let l:candidates = split(a:data[0], " ")
   let l:items = s:generate_items(l:candidates)
 
-  call asyncomplete#complete(s:opt["name"], s:ctx, l:startcol, l:items)
+  call asyncomplete#complete(s:opt["name"], s:ctx, l:startcol, l:items, 1)
 endfunction
 
 function! s:generate_items(candidates)

--- a/autoload/asyncomplete/sources/mocword.vim
+++ b/autoload/asyncomplete/sources/mocword.vim
@@ -9,9 +9,12 @@ function! asyncomplete#sources#mocword#get_source_options(opt) abort
   if !has_key(opt, "args")
     let opt["args"] = ["--limit", "100"]
   endif
+  return opt
+endfunction
 
+function! asyncomplete#sources#mocword#completor(opt, ctx) abort
   if !exists("s:mocword_job")
-    let s:mocword_job = asyncomplete#mocword#job#start(["mocword"] + opt["args"], { "on_stdout": function("s:on_event") })
+    let s:mocword_job = asyncomplete#mocword#job#start(["mocword"] + a:opt["args"], { "on_stdout": function("s:on_event") })
 
     if s:mocword_job <= 0
       echoerr "mocword launch failed"
@@ -20,10 +23,6 @@ function! asyncomplete#sources#mocword#get_source_options(opt) abort
     let s:ctx = {}
   endif
 
-  return opt
-endfunction
-
-function! asyncomplete#sources#mocword#completor(opt, ctx) abort
   if s:mocword_job <= 0
     return
   endif


### PR DESCRIPTION
Plugin starts background mocword job in get_source_options. So it runs even if no completion is ever attempted.  Worse, it seems to interfere with gvim forking into the background. I moved the job start code into the completor function, so it doesn't happen until the first time it is needed. By that time gvim has already forked.